### PR TITLE
Wrong language code for Danish

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Currently supported languages:
 
 - cs
 - de
-- dk
+- da
 - en
 - es
 - fr

--- a/src/share.js
+++ b/src/share.js
@@ -96,6 +96,15 @@ navigator.share = navigator.share || (function(){
 			email: 'E-mail',
 			selectSms: 'Selecteer een contact'
 		},
+    da: {
+			shareTitle: 'Del',
+			cancel: 'Luk',
+			copy: 'Kopiér',
+			print: 'Udskriv',
+			email: 'E-mail',
+			selectSms: 'Vælg en kontaktperson'
+		},
+    // Deprecated, use `da` instead.
     dk: {
 			shareTitle: 'Del',
 			cancel: 'Luk',


### PR DESCRIPTION
The [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for Danish is `da`, not `dk`.

I kept the entry for `dk` for backwards compatibility. The code `dk` is currently undefined in ISO 639, so there is no conflict.